### PR TITLE
fallback to build sysimage if it is not available upstream

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,2 +1,8 @@
 using Comonicon, IonCLI
-Comonicon.install(IonCLI)
+try
+    Comonicon.install(IonCLI)
+catch err
+    @warn "failed to download prebuilt sysimage" err
+    @info "fallback to build sysimage in your local machine, this could take a few minutes"
+    IonCLI.comonicon_build()
+end


### PR DESCRIPTION
Not very sure if this is desired for a long-term design, but it is quite confusing for the first-time users that adding this package could easily fails at the build stage.